### PR TITLE
Implement lic_14

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -281,5 +281,37 @@ def lic_13(parameters, points):
     return helper(radius1) and helper(radius2)
 
 def lic_14(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether both the following conditions are true:
+    - any three points with E_PTS and F_PTS consecutive intervening points cannot all be contained in a triangle with area AREA1
+    - any three points with E_PTS and F_PTS consecutive intervening points can be contained in a triangle with area AREA2
+    If they are, return true. If they are not, return false.
+    """
+    if len(points) < 5:
+        return False
+    e_pts = parameters["e_pts"]
+    f_pts = parameters["f_pts"]
+    area1 = parameters["area1"]
+    area2 = parameters["area2"]
+    def helper(max_area):
+        """
+        Checks whether any three points with E_PTS and F_PTS consecutive intervening points
+        cannot all be contained in a triangle with the specified area
+        """
+        for i in range(len(points) - 2 - e_pts - f_pts):
+            p1 = points[i]
+            p2 = points[i+1+e_pts]
+            p3 = points[i+2+e_pts+f_pts]
+
+            a = dist(p1, p2)
+            b = dist(p1, p3)
+            c = dist(p2, p3)
+
+            # Semi-perimeter
+            s = (a+b+c)/2
+
+            # Heron's formula
+            area = sqrt(s*(s-a)*(s-b)*(s-c))
+
+            return area > max_area
+    return helper(area1) and not helper(area2)

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -493,3 +493,63 @@ def test_lic_13_false_2():
     points = [(2.0, 0.0), (0.0, 0.0), (0.0, 0.0), (25.0, 25.0), (0.0, 2.0), (0.0, 0.0), (3.0, 0.0)]
     result = lic_13(parameters, points)
     assert(not result)
+
+def test_lic_14_true():
+    """
+    Tests that lic_14 returns true if both the following conditions are true:
+    - any three points with E_PTS and F_PTS consecutive intervening points cannot all be contained in a triangle with area AREA1
+    - any three points with E_PTS and F_PTS consecutive intervening points can be contained in a triangle with area AREA2
+    """
+    parameters = {
+        "area1": 0.5,
+        "area2": 2.0,
+        "e_pts": 1,
+        "f_pts": 1
+    }
+    points = [(3.0, 1.0), (0.0, 0.0), (1.0, 3.0), (0.0, 0.0), (1.0, 1.0)]
+    result = lic_14(parameters, points)
+    assert(result)
+
+def test_lic_14_false_1():
+    """
+    Tests that lic_14 returns false if three points with E_PTS and F_PTS consecutive intervening points can be contained in a triangle with area AREA1
+    """
+    parameters = {
+        "area1": 2.0,
+        "area2": 3,
+        "e_pts": 2,
+        "f_pts": 2
+    }
+    points = [(2.0, 1.0), (0.0, 0.0), (1.0, 1.0), (1.0, 2.0), (5.0, 3.0), (0.0, 0.0), (1.0, 1.0)]
+    result = lic_14(parameters, points)
+    assert(not result)
+
+def test_lic_14_false_2():
+    """
+    Tests that lic_14 returns false if both the following conditions are true:
+    - any three points with E_PTS and F_PTS consecutive intervening points can be contained in a triangle with area AREA1
+    - any three points with E_PTS and F_PTS consecutive intervening points cannot be contained in a triangle with area AREA2
+    """
+    parameters = {
+        "area1": 2.0,
+        "area2": 0.0,
+        "e_pts": 0,
+        "f_pts": 2
+    }
+    points = [(2.0, 1.0), (1.0, 2.0), (5.0, 3.0), (0.0, 0.0), (1.0, 1.0)]
+    result = lic_14(parameters, points)
+    assert(not result)
+
+def test_lic_14_too_few_points():
+    """
+    Tests that lic_14 returns false if there are fewer than 5 points
+    """
+    parameters = {
+        "area1": 0.0,
+        "area2": 0.0,
+        "e_pts": 0,
+        "f_pts": 1
+    }
+    points = [(-3.0, -1.0), (-1.0, -3.0), (0.0, 0.0), (-1.0, -1.0)]
+    result = lic_14(parameters, points)
+    assert(not result)


### PR DESCRIPTION
This adds an implementation for the lic_14 function that checks whether both of the following conditions are true:
- any three points with E_PTS and F_PTS consecutive intervening points cannot all be contained in a triangle with area AREA1
- any three points with E_PTS and F_PTS consecutive intervening points cannot all be contained in a triangle with area AREA2 If they both are true, it returns true. Otherwise, it returns false. Additionally, this adds four new unit tests.

Fixes #9