### PR TITLE
Implement lic_8

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -213,8 +213,42 @@ def lic_7(parameters, points):
     return False
 
 def lic_8(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS1
+    """
+    if len(points) < 5:
+        return False
+    a_pts = parameters["a_pts"]
+    b_pts = parameters["b_pts"]
+    radius1 = parameters["radius1"]
+    for i in range(len(points) - 2 - a_pts - b_pts):
+        p1 = points[i]
+        p2 = points[i+1+a_pts]
+        p3 = points[i+2+a_pts+b_pts]
+
+        a = dist(p1, p2)
+        b = dist(p1, p3)
+        c = dist(p2, p3)
+
+        # Semi-perimeter
+        s = (a+b+c)/2
+
+        # Heron's formula
+        area = sqrt(s*(s-a)*(s-b)*(s-c))
+
+        # If the area is zero, then the triangle is degenerate, i.e. a+b=c for a≤b≤c
+        if area == 0.0:
+            if max(a, b, c) > 2*radius1:
+                return True
+            else:
+                continue
+
+        # All other triangles
+        circumradius = a*b*c/(4*area)
+
+        if circumradius > radius1:
+            return True
+    return False
 
 def lic_9(parameters, points):
     # TODO: Implement

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -447,6 +447,75 @@ def test_lic_7_too_few_points():
     result = lic_7(parameters, points)
     assert not result
 
+def test_lic_8_true():
+    """
+    Tests that lic_8 returns true when three points with A_PTS and B_PTS consecutive intervening points
+    cannot all be contained in a circle with radius RADIUS1
+    """
+    parameters = {
+        "radius1": 1.0,
+        "a_pts": 1,
+        "b_pts": 1
+    }
+    points = [(0.0, 0.0), (-1.0, -2.0), (5.0, 0.0), (1.0, 2.0), (0.0, 5.0)]
+    result = lic_8(parameters, points)
+    assert(result)
+
+def test_lic_8_false():
+    """
+    Tests that lic_8 returns false when three points with A_PTS and B_PTS consecutive intervening points
+    can all be contained in a circle with radius RADIUS1
+    """
+    parameters = {
+        "radius1": 10.0,
+        "a_pts": 2,
+        "b_pts": 1
+    }
+    points = [(1.0, 1.0), (-1.0, -2.0), (0.0, 0.0), (3.0, 1.0), (1.0, 2.0), (3.0, 1.0)]
+    result = lic_8(parameters, points)
+    assert(not result)
+
+def test_lic_8_degenerate_triangle_true():
+    """
+    Tests that lic_8 returns true if three points with A_PTS and B_PTS consecutive intervening points that
+    form a degenerate triangle (i.e. a+b=c for a≤b≤c) cannot all be contained in a circle with radius RADIUS1
+    """
+    parameters = {
+        "radius1": 2.9,
+        "a_pts": 1,
+        "b_pts": 2
+    }
+    points = [(0.0, 0.0), (-2.0, -7.0), (3.0, 0.0), (0.0, 3.0), (1.0, 4.0), (-3.0, 0.0)]
+    result = lic_8(parameters, points)
+    assert(result)
+
+def test_lic_8_degenerate_triangle_false():
+    """
+    Tests that lic_8 returns false if three points with A_PTS and B_PTS consecutive intervening points that
+    form a degenerate triangle (i.e. a+b=c for a≤b≤c) can be contained in a circle with radius RADIUS1
+    """
+    parameters = {
+        "radius1": 3.0,
+        "a_pts": 1,
+        "b_pts": 2
+    }
+    points = [(0.0, 0.0), (-2.0, -7.0), (3.0, 0.0), (0.0, 3.0), (1.0, 4.0), (-3.0, 0.0)]
+    result = lic_8(parameters, points)
+    assert(not result)
+
+def test_lic_8_too_few_points():
+    """
+    Tests that lic_8 returns false when there are less than 5 points
+    """
+    parameters = {
+        "radius1": 0.0,
+        "a_pts": 0,
+        "b_pts": 1
+    }
+    points = [(0.0, 0.0), (-1.0, -2.0), (3.0, 0.0), (1.0, 2.0)]
+    result = lic_8(parameters, points)
+    assert(not result)
+
 def test_lic_13_true():
     """
     Tests that lic_13 returns true if both the following conditions are true:


### PR DESCRIPTION
This adds an implementation for the lic_8 function that checks whether any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS1. This also adds 5 unit tests that cover the true case, the false case and edge cases (i.e. when the triangle is degenerate or there are fewer than 5 points).

Fixes #13