### PR TITLE
Implement lic_9

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -1,4 +1,4 @@
-from math import sqrt, acos, pi, dist
+from math import sqrt, acos, pi, dist, hypot
 
 def cmv(parameters, points):
     cmv = [False] * 15
@@ -251,8 +251,44 @@ def lic_8(parameters, points):
     return False
 
 def lic_9(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether or not there exists at least one set of three points, separated by [c_pts] and [d_pts] consecutive points,
+    that form an angle that is either < pi - epsilon or > pi + epsilon. The middle point is the vertex of the angle and the condition
+    is not fulfilled if any of the other points of the angle coincide with the vertex. 
+    """
+    if len(points) < 5:
+        return False
+    
+    epsilon = parameters["epsilon"]
+    c_pts = parameters["c_pts"]
+    d_pts = parameters["d_pts"]
+
+    for i in range(len(points) - (c_pts + d_pts + 2)):
+        p1 = points[i]
+        p2 = points[i+c_pts+1] # vertex
+        p3 = points[i+c_pts+d_pts+2]
+
+        a = (p1[0] - p2[0], p1[1] - p2[1])
+        b = (p3[0] - p2[0], p3[1] - p2[1])
+
+        len_a = hypot(*a)
+        len_b = hypot(*b)
+
+        if len_a == 0 or len_b == 0: # point(s) coincide with vertex
+            continue
+
+        tmp = (a[0]*b[0] + a[1]*b[1]) / (len_a*len_b)
+
+        # avoid acos domain errors due to float accuracy
+        if abs(tmp - 1) < 1e-5:
+            tmp = 1.0
+        if abs(tmp + 1) < 1e-5:
+            tmp = -1.0
+
+        angle = acos(tmp) # if the points lie on a straight line, the angle will be considered to be 0
+        if angle < pi - epsilon: # equivalent to alternative angle > pi + epsilon
+            return True
+    return False
 
 def lic_10(parameters, points):
     """

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -516,6 +516,72 @@ def test_lic_8_too_few_points():
     result = lic_8(parameters, points)
     assert(not result)
 
+def test_lic_9_true():
+    """
+    Tests that lic_9 returns true when there is a set of three points separated by [c_pts] and [d_pts] consecutive points
+    that form an angle that is smaller than pi - [epsilon]
+    """
+    parameters = {
+        "c_pts": 1,
+        "d_pts": 1,
+        "epsilon": pi/4
+    }
+    points = [(0.0, 1.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0), (1.0, 0.0)] # pi/2 angle
+    result = lic_9(parameters, points)
+    assert result
+
+def test_lic_9_false():
+    """
+    Tests that lic_9 returns false when there is no set of points that form an angle smaller than pi - [epsilon]
+    """
+    parameters = {
+        "c_pts": 1,
+        "d_pts": 1,
+        "epsilon": 3*pi/4
+    }
+    points = [(0.0, 1.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0), (1.0, 0.0)] # pi/2 angle
+    result = lic_9(parameters, points)
+    assert not result
+
+def test_lic_9_false_coinciding_point1():
+    """
+    Tests that lic_9 returns false when the first point coincides with the vertex
+    """
+    parameters = {
+            "c_pts": 2,
+            "d_pts": 1,
+            "epsilon": pi/2
+        }
+    points = [(0.0, 0.0), (-1.0, -1.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0), (2.0, 2.0)]
+    result = lic_9(parameters, points)
+    assert not result
+
+def test_lic_9_false_coinciding_point2():
+    """
+    Tests that lic_9 returns false when the second point coincides with the vertex
+    """
+    parameters = {
+            "c_pts": 2,
+            "d_pts": 1,
+            "epsilon": pi/2
+        }
+    points = [(0.0, 1.0), (-1.0, -1.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0), (0.0, 0.0)]
+    result = lic_9(parameters, points)
+    assert not result
+
+def test_lic_9_false_too_few_points():
+    """
+    Tests that lic_9 returns false when there are less than 5 points
+    """
+    parameters = {
+            "c_pts": 1,
+            "d_pts": 1,
+            "epsilon": pi/4
+        }
+    points = [(0.0, 1.0), (-1.0, -1.0), (0.0, 0.0)] 
+    result = lic_9(parameters, points)
+    assert not result
+
 def test_lic_10_true():
     """
     Tests that lic_10 returns true when there exists a set of three points separated by [e_pts] and [f_pts]


### PR DESCRIPTION
This implements lic_9 which checks if there is a set of three points, separated by [c_pts] and [d_pts] consecutive points, which form an angle that is smaller than pi - [epsilon], or equivalently, greater than pi + [epsilon].

Also adds some unit tests to verify the behaviour.

Note that if all points lie on a straight line, the angle will be considered as 0 and not as pi.

Fixes #4