### PR TITLE
Fix ModuleNotFoundError

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = . src

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,8 @@
 from ast import literal_eval
 from math import pi
-from src.cmv import cmv
-from src.pum import pum
-from src.fuv import fuv
+from cmv import cmv
+from pum import pum
+from fuv import fuv
 
 def decide(num_points, points, parameters, lcm, puv):
     cmv_res = cmv(parameters, points)


### PR DESCRIPTION
This fixes the ModuleNotFoundError that would arise when running main.py by adding the repo and src folders to pythonpath in pytest.ini

Fixes #20